### PR TITLE
when an is not enabled it should not add AN framework to project.

### DIFF
--- a/main.js
+++ b/main.js
@@ -204,6 +204,7 @@ async function handleEvent(options, cb) {
 
     if (!config.enable || !config.audience.enable) {
         cb && cb();
+        return;
     }
 
     if (options.actualPlatform.toLowerCase() === 'android') {


### PR DESCRIPTION
when an is not enabled it should not add AN framework to project.